### PR TITLE
Fill payload's body and schema with resolved asset

### DIFF
--- a/src/drafter.coffee
+++ b/src/drafter.coffee
@@ -55,6 +55,7 @@ generateBody = (payload, attributes, contentType, callback) ->
         content: body
 
       payload.content.push resolved
+      payload.body = body
 
     # For waterfall
     callback null, payload, attributes, contentType
@@ -80,6 +81,7 @@ generateSchema = (payload, attributes, contentType, callback) ->
         content: body
 
       payload.content.push resolved
+      payload.schema = body
 
     # For waterfall
     callback null, payload, attributes, contentType

--- a/test/fixtures/dataStructures.ast.json
+++ b/test/fixtures/dataStructures.ast.json
@@ -59,8 +59,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"id\":\"250FF\",\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "dataStructure",
@@ -763,8 +763,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "resolvedAsset",
@@ -793,8 +793,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"id\":\"250FF\",\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "dataStructure",
@@ -2606,8 +2606,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"id\":\"250FF\",\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "dataStructure",
@@ -3310,8 +3310,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "resolvedAsset",
@@ -3340,8 +3340,8 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": "",
+                      "body": "{\"id\":\"250FF\",\"percent_off\":25,\"redeem_by\":null,\"created\":null,\"modified\":null,\"created_at\":null,\"updated_at\":null}",
+                      "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"percent_off\":{\"type\":\"number\"},\"redeem_by\":{\"type\":\"number\",\"description\":\"Date after which the coupon can no longer be redeemed\"},\"created\":{\"type\":\"number\"},\"modified\":{\"type\":\"number\"},\"created_at\":{\"type\":\"number\"},\"updated_at\":{\"type\":\"number\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}",
                       "content": [
                         {
                           "element": "dataStructure",


### PR DESCRIPTION
When a payload's body and schema are empty but if the payload has attributes, we can resolve it's assets using the given attributes and fill up the `payload.body` and `payload.schema`.

This PR fills up the `payload.body` and `payload.schema`.