### PR TITLE
Fix bugs which have been occurring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Apiary.io <support@apiary.io>",
   "description": "Snow Crash parser harness",
   "license": "MIT",

--- a/src/rules/mson-inheritance.coffee
+++ b/src/rules/mson-inheritance.coffee
@@ -63,8 +63,9 @@ module.exports =
         dataStructure.sections.push memberTypeSection
         dataStructure.typeDefinition.typeSpecification.nestedTypes = []
 
-    if superType is null or typeof superType isnt 'object' or not superType?.literal
-      return @expanded[superType] = true
+    # Make sure super type is valid
+    if superType is null or typeof superType isnt 'object' or not superType?.literal or not @dataStructures[superType.literal]
+      return @expanded[name] = true
 
     # Expand the super type first
     @expandInheritance superType.literal, @dataStructures[superType.literal]

--- a/src/rules/mson-member-type-name.coffee
+++ b/src/rules/mson-member-type-name.coffee
@@ -30,7 +30,7 @@ module.exports =
           superType = member.content.valueDefinition.typeDefinition.typeSpecification.name
 
           # If super type is a valid symbol
-          if typeof superType is 'object' and superType?.literal
+          if typeof superType is 'object' and superType?.literal and @dataStructures[superType.literal]
             @expandMember superType.literal, @dataStructures[superType.literal]
 
             superTypeBaseName = @dataStructures[superType.literal].typeDefinition.typeSpecification.name

--- a/src/rules/mson-mixin.coffee
+++ b/src/rules/mson-mixin.coffee
@@ -30,9 +30,12 @@ module.exports =
         when 'mixin'
           superType = member.content.typeSpecification.name
 
-          # Expand the super type first
-          @expandMixin superType.literal, @dataStructures[superType.literal]
-          rule.copyMembers @dataStructures[superType.literal], sectionOrMember
+          # Make sure the super type exists
+          if typeof superType is 'object' and superType?.literal and @dataStructures[superType.literal]
+
+            # Expand the super type first
+            @expandMixin superType.literal, @dataStructures[superType.literal]
+            rule.copyMembers @dataStructures[superType.literal], sectionOrMember
 
         when 'oneOf', 'group'
           memberType =

--- a/src/rules/rule.coffee
+++ b/src/rules/rule.coffee
@@ -5,7 +5,7 @@ module.exports =
   # @param dataStructure [Object] The super type data structure
   # @param memberTypeSection [Object] Member Type Section to be copied into
   copyMembers: (dataStructure, memberTypeSection) ->
-    return if not dataStructure
+    return if not dataStructure or not memberTypeSection
 
     for section in dataStructure.sections
       if section['class'] is 'memberType'

--- a/test/unit/drafter-test.coffee
+++ b/test/unit/drafter-test.coffee
@@ -23,3 +23,49 @@ describe 'Drafter Class', ->
       assert.deepEqual result.ast, require '../fixtures/dataStructures.ast.json'
 
       done()
+
+  it 'parses correctly when super type of a member is not found', (done) ->
+    drafter = new Drafter
+
+    blueprint = '''
+    # Polls [/]
+
+    + Attributes
+        + owner (Person)
+    '''
+
+    drafter.make blueprint, (error, result) ->
+      assert.isNull error
+      assert.ok result.ast
+      done()
+
+  it 'parses correctly when super type of a type is not found', (done) ->
+    drafter = new Drafter
+
+    blueprint = '''
+    # Polls [/]
+    ## Get a Poll [GET]
+
+    + Attributes (Person)
+        + id
+    '''
+
+    drafter.make blueprint, (error, result) ->
+      assert.isNull error
+      assert.ok result.ast
+      done()
+
+  it 'parses correctly when named type in a mixin is not found', (done) ->
+    drafter = new Drafter
+
+    blueprint = '''
+    # Polls [/]
+
+    + Attributes
+        + Include Person
+    '''
+
+    drafter.make blueprint, (error, result) ->
+      assert.isNull error
+      assert.ok result.ast
+      done()

--- a/test/unit/drafter-test.coffee
+++ b/test/unit/drafter-test.coffee
@@ -69,3 +69,18 @@ describe 'Drafter Class', ->
       assert.isNull error
       assert.ok result.ast
       done()
+
+  it 'parses correctly when named type in a mixin is a primitive type', (done) ->
+    drafter = new Drafter
+
+    blueprint = '''
+    # Polls [/]
+
+    + Attributes
+        + Include string
+    '''
+
+    drafter.make blueprint, (error, result) ->
+      assert.isNull error
+      assert.ok result.ast
+      done()


### PR DESCRIPTION
Whenever some named types are not found, since snowcrash gives us warnings, drafter doesn't check for their existence. This PR makes sure that drafter.js checks if they the given named types are valid or not.