### PR TITLE
Parse correctly when a resource has no name but has attributes

### DIFF
--- a/src/drafter.coffee
+++ b/src/drafter.coffee
@@ -197,12 +197,15 @@ class Drafter
 
             switch subElement.element
               when 'dataStructure'
-                @dataStructures[subElement.name.literal] = deepcopy subElement
-                @origDataStructures[subElement.name.literal] = subElement
-                @appendResolved[subElement.name.literal] = element.content
+                if typeof subElement.name is 'object' and subElement.name?.literal
+
+                  @dataStructures[subElement.name.literal] = deepcopy subElement
+                  @origDataStructures[subElement.name.literal] = subElement
+                  @appendResolved[subElement.name.literal] = element.content
+
               when 'resource'
                 for resourceSubElement in subElement.content
-                  if resourceSubElement.element is 'dataStructure'
+                  if resourceSubElement.element is 'dataStructure' and typeof resourceSubElement.name is 'object' and resourceSubElement.name?.literal
 
                     @dataStructures[resourceSubElement.name.literal] = deepcopy resourceSubElement
                     @origDataStructures[resourceSubElement.name.literal] = resourceSubElement

--- a/test/unit/drafter-test.coffee
+++ b/test/unit/drafter-test.coffee
@@ -84,3 +84,18 @@ describe 'Drafter Class', ->
       assert.isNull error
       assert.ok result.ast
       done()
+
+  it 'parses correctly when resource has no name but has attributes', (done) ->
+    drafter = new Drafter
+
+    blueprint = '''
+    # /
+
+    + Attributes
+      + id
+    '''
+
+    drafter.make blueprint, (error, result) ->
+      assert.isNull error
+      assert.ok result.ast
+      done()


### PR DESCRIPTION
Snowcrash should ideally give an error when this is happening. That is fixed in apiaryio/snowcrash#315.

But, I still added the checks here.
