### PR TITLE
[package.json] Remove duplicate license

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
     "coffee-script": "~1.7.1",
     "chai": "~1.10.0",
     "mocha": "~2.0.1"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
`"license": "MIT"` was found twice in package.json.