### PR TITLE
Tweaks to build settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ binding.
 ## Installation
 
 drafter.js can be installed from NPM, or it can be downloaded from the [releases
-page](https://github.com/apiaryio/drafter/releases.js).
+page](https://github.com/apiaryio/drafter/releases).
 
 ```shell
 $ npm install drafter.js
@@ -28,8 +28,13 @@ If you've installed drafter.js via NPM and using drafter.js in Node, you can
 require it via:
 
 ```javascript
-
+var drafter = require('drafter.js')
 ```
+
+*Node versions supported*: >=0.12
+
+It works on 0.10 too but without any guarantees and expect it to be
+significantly slower.
 
 ### Web Browser
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ moment.*
 2. Build
 
     ```shell
-    $ docker pull "apiaryio/base-emscripten-dev"
-    $ docker run -v $(pwd):/src -t apiaryio/base-emscripten-dev emcc/emcbuild.sh
+    $ docker pull "apiaryio/emcc:1.36"
+    $ docker run -v $(pwd):/src -t apiaryio/emcc:1.36 emcc/emcbuild.sh
+    ```
+    or with `npm`
+    ```shell
+    $ npm run build
     ```
 
 3. Check out the `./scripts/test.js` and `./scripts/test.html` files for
@@ -110,7 +114,8 @@ moment.*
 The resulting stand-alone library `drafter.js` is in the `./lib` directory.
 Don't forget to serve the `drafter.js.mem` file as it is required by
 `drafter.js`. There is also a single-file version in `drafter.nomem.js` that
-can be used, but it may take longer to load in a web browser environment.
+can be used, but it may take longer to load in a web browser
+environment. It is the default for node.js enviroment.
 
 To get a debug version or version enabled to be used with `emrun` run
 the `emcbuild.sh` script it with `-d` or `-e` respectively.
@@ -119,10 +124,10 @@ the `emcbuild.sh` script it with `-d` or `-e` respectively.
 
 If you want to squeeze the size to a minimum install
 [uglify-js](https://github.com/mishoo/UglifyJS2) and try running
-`emcbuild.sh -u`, this will use `uglify-js` with compression, beware
-that this might cause some errors, if you encounter them try
-`drafter.js` without it to verify that it is caused by `uglify-js`
-and report it please.
+`uglifyjs lib/drafter.js -o drafter.js -c;`, this will use
+`uglify-js` with compression, beware that this might cause some
+errors, if you encounter them try `drafter.js` without it to verify
+that it is caused by `uglify-js` and report it please.
 
 ## License
 MIT License. See the [LICENSE](https://github.com/apiaryio/drafter.js/blob/master/LICENSE) file.

--- a/circle.yml
+++ b/circle.yml
@@ -15,18 +15,18 @@ checkout:
 
 dependencies:
   cache_directories:
-    - "~/docker"
+    - "~/emcc-1.36"
   pre:
-    - if [[ ! -f ~/docker/emscripten.tar ]]; then mkdir -p ~/docker &&
-      docker pull "apiaryio/base-emscripten-dev" &&
-      docker save "apiaryio/base-emscripten-dev" > ~/docker/emscripten.tar;
-      else docker load -i ~/docker/emscripten.tar; fi
+    - if [[ ! -f ~/emcc-1.36/emscripten.tar ]]; then mkdir -p ~/emcc-1.36 &&
+      docker pull "apiaryio/emcc:1.36" &&
+      docker save "apiaryio/emcc:1.36" > ~/emcc-1.36/emscripten.tar;
+      else docker load -i ~/emcc-1.36/emscripten.tar; fi
   post:
     - cd ext/drafter && ./configure && make drafter
 
 test:
   pre:
-    - docker run -v $(pwd):/src -t apiaryio/base-emscripten-dev scripts/emcbuild.sh
+    - npm run build
 
 deployment:
   release:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
   services:
     - docker
   node:
-    version: "0.10"
+    version: "0.12"
 
 checkout:
   post:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "browser": {
     "ws": false
   },
+  "engines": {
+    "node": ">= 0.12"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apiaryio/drafter.js"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "drafter.js",
   "version": "2.3.1",
   "description": "Pure JS Drafter built with Emscripten",
-  "main": "emcc/drafter.nomem.js",
+  "main": "lib/drafter.nomem.js",
   "scripts": {
-    "test": "node scripts/test.js"
+    "test": "node scripts/test.js",
+    "build": "docker run --rm -v $(pwd):/src -t apiaryio/emcc:1.36 scripts/emcbuild.sh",
+    "clean": "docker run --rm -v $(pwd):/src -t apiaryio/emcc:1.36 scripts/emcclean.sh",
+    "release": "scripts/release.sh"
   },
   "browser": {
     "ws": false

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -24,6 +24,7 @@ var testRun = {
   pass: 0,
   fail: 0,
   jsTime: 0,
+  prtgTime: 0,
   cppTime: 0
 };
 
@@ -153,6 +154,7 @@ function testSerialization(filename, type, done) {
     }
 
     testRun.cppTime += results.cpp.duration;
+    testRun.prtgTime += results.protagonist.duration;
     testRun.jsTime += results.js.duration;
 
     done();
@@ -179,7 +181,7 @@ async.eachLimit(glob.sync('ext/drafter/test/**/*.apib'), 1, testFile, function (
   console.log('Total:  ' + testRun.total);
   console.log('Passed: ' + testRun.pass);
   console.log('Failed: ' + testRun.fail);
-  console.log('Average JS speed: ' + (testRun.jsTime / testRun.cppTime).toFixed(1) + ' times slower than C++');
+  console.log('Average JS speed: ' + (testRun.jsTime / testRun.cppTime).toFixed(1) + ' times slower than C++ and ' + (testRun.jsTime / testRun.prtgTime).toFixed(1) + ' times slower than Protagonist');
 
   process.exit(testRun.fail > 0 ? -1 : 0);
 });

--- a/src/post.js
+++ b/src/post.js
@@ -20,8 +20,7 @@ Module['parse'] = function(blueprint, options, callback) {
   }
 
   var chptr = _malloc(4);
-  // at most 4 bytes per UTF-8 code point, +1 for the trailing '\0'
-  var buffer = _malloc(4*blueprint.length+1);
+  var buffer = _malloc(lengthBytesUTF8(blueprint) + 1);
   var parseOptions = 0;
   var astType = 1;
 


### PR DESCRIPTION
- npm run build (build default options)
- npm run clean (remove all the build artifacts)
- test.js measures and prints protagonist too
- removing uglify, benefits are small so by default we are not going to support it

Circle caching changed so that we get always the explicit version and the cache won't mess it up