### PR TITLE
Ship lib as UMD package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /lib
+generated

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ moment.*
 2. Build
 
     ```shell
+    $ ./scripts/wrap.js
     $ docker pull "apiaryio/emcc:1.36"
     $ docker run -v $(pwd):/src -t apiaryio/emcc:1.36 emcc/emcbuild.sh
     ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/drafter.nomem.js",
   "scripts": {
     "test": "node scripts/test.js",
-    "build": "docker run --rm -v $(pwd):/src -t apiaryio/emcc:1.36 scripts/emcbuild.sh",
+    "build": "./scripts/wrap.js && docker run --rm -v $(pwd):/src -t apiaryio/emcc:1.36 scripts/emcbuild.sh",
     "clean": "docker run --rm -v $(pwd):/src -t apiaryio/emcc:1.36 scripts/emcclean.sh",
     "release": "scripts/release.sh"
   },
@@ -30,6 +30,8 @@
     "chai": "^3.3.0",
     "chalk": "^1.1.1",
     "diff": "^2.1.3",
-    "glob": "^5.0.15"
+    "glob": "^5.0.15",
+    "mkdirp": "^0.5.1",
+    "umd": "^3.0.1"
   }
 }

--- a/scripts/emcbuild.sh
+++ b/scripts/emcbuild.sh
@@ -86,8 +86,8 @@ em++ $FLAGS "$DRAFTER_PATH/build/out/$BUILD_TYPE/lib.target/libdrafter.so" \
   -s ELIMINATE_DUPLICATE_FUNCTIONS=1 \
   -s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
   -o lib/drafter.js  \
-  --pre-js src/pre.js \
-  --post-js src/post.js
+  --pre-js generated/pre.js \
+  --post-js generated/post.js
 
 em++ $FLAGS --memory-init-file 0 "$DRAFTER_PATH/build/out/$BUILD_TYPE/lib.target/libdrafter.so" \
   -s EXPORTED_FUNCTIONS="['_drafter_c_parse']" \
@@ -103,6 +103,6 @@ em++ $FLAGS --memory-init-file 0 "$DRAFTER_PATH/build/out/$BUILD_TYPE/lib.target
   -s NO_FILESYSTEM=1 \
   -s ELIMINATE_DUPLICATE_FUNCTIONS=1 \
   -o lib/drafter.nomem.js \
-  --pre-js src/pre.js \
-  --post-js src/post.js
+  --pre-js generated/pre.js \
+  --post-js generated/post.js
 

--- a/scripts/emcclean.sh
+++ b/scripts/emcclean.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 cd ext/drafter && make clean
+rm -rf generated
 rm -rf ./lib/drafter.js ./lib/drafter.js.mem ./lib/drafter.nomem.js

--- a/scripts/wrap.js
+++ b/scripts/wrap.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+var umd = require('umd');
+var mkdirp = require('mkdirp').sync;
+
+var generatedDir = path.join(__dirname, '../generated/');
+var srcDir = path.join(__dirname, '../src/');
+var pre = fs.readFileSync(srcDir + 'pre.js');
+var post = fs.readFileSync(srcDir + 'post.js');
+
+pre = umd.prelude('drafter') + pre;
+post += '\nreturn Module;' +umd.postlude('drafter');
+
+mkdirp(generatedDir);
+
+fs.writeFileSync(generatedDir + 'pre.js', pre);
+fs.writeFileSync(generatedDir + 'post.js', post);

--- a/src/post.js
+++ b/src/post.js
@@ -80,5 +80,3 @@ Module['parse'] = function(blueprint, options, callback) {
 Module['parseSync'] = function(blueprint, options) {
   return Module.parse(blueprint, options);
 };
-
-var drafter = Module;


### PR DESCRIPTION
I spent last few days trying to use your lib as part of the browserify build.
The biggest problem is that you expose your lib as a variable in local scope, so if it wrapped in a function there are no ways to access it. I don't want to introduce any browserify specific code into the lib instead I used UMD wrapper which works with all popular package managers.

I used this tool to generate wrapper:  https://github.com/ForbesLindesay/umd
Generated code is small and simple so I just copy-paste it.