### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,13 @@
 .gitmodules
 .npmrc
-src/pre.js
-src/post.js
+src/
 ext/
 scripts/
 circle.yml
 *github-release*
 drafter.js-*.tgz
+configure
+generated/
+*.gypi
+*.gyp
+build/


### PR DESCRIPTION
NPM try to build gyp files during instalation:
```
> drafter.js@2.4.0 install /Users/ivang/dev/api-spec-converter/node_modules/drafter.js
> node-gyp rebuild

gyp: ext/drafter/ext/snowcrash/common.gypi not found (cwd: /Users/ivang/dev/api-spec-converter/node_modules/drafter.js) while reading includes of binding.gyp while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:305:16)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Darwin 15.5.0
gyp ERR! command "/usr/local/Cellar/node/6.2.2/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/ivang/dev/api-spec-converter/node_modules/drafter.js
gyp ERR! node -v v6.2.2
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
npm ERR! Darwin 15.5.0
npm ERR! argv "/usr/local/Cellar/node/6.2.2/bin/node" "/usr/local/bin/npm" "install" "drafter.js"
npm ERR! node v6.2.2
npm ERR! npm  v3.9.5
npm ERR! code ELIFECYCLE
```

Package also include many unnecessary files:
```
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/configure
x package/build/Makefile
x package/build/drafterjs.Makefile
x package/build/ext/drafter/drafter.Makefile
x package/build/ext/drafter/drafter.target.mk
x package/build/ext/drafter/ext/snowcrash/libmarkdownparser.target.mk
x package/build/ext/drafter/ext/snowcrash/libsnowcrash.target.mk
x package/build/ext/drafter/ext/snowcrash/libsundown.target.mk
x package/build/ext/drafter/ext/snowcrash/perf-libsnowcrash.target.mk
x package/build/ext/drafter/ext/snowcrash/snowcrash.Makefile
x package/build/ext/drafter/ext/snowcrash/test-libsnowcrash.target.mk
x package/build/ext/drafter/libdrafter.target.mk
x package/build/ext/drafter/libsos.target.mk
x package/build/ext/drafter/test-capi.target.mk
x package/build/ext/drafter/test-libdrafter.target.mk
x package/build/libdrafterjs.target.mk
x package/build/out/Release/.deps/out/Release/libdrafterjs.a.d
x package/build/out/Release/.deps/out/Release/obj.target/libdrafterjs/src/cparse.o.d
x package/build/out/Release/.deps/out/Release/obj.target/libdrafterjs.a.d
x package/build/out/Release/libdrafterjs.a
x package/build/out/Release/obj.target/libdrafterjs/src/cparse.o
x package/build/out/Release/obj.target/libdrafterjs.a: Can't create 'package/build/out/Release/obj.target/libdrafterjs.a'
x package/config.gypi
x package/binding.gyp
x package/drafterjs.gypi
x package/generated/post.js
x package/generated/pre.js
x package/lib/drafter.js
x package/lib/drafter.nomem.js
x package/lib/drafter.js.mem
x package/CHANGELOG.md
x package/src/cparse.cc
x package/src/cparse.h
```