### PR TITLE
Release 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # drafter.js Changelog
 
+## 2.4.1
+
+### Bug Fixes
+
+- Removes unnecessary files from the NPM package. 2.4.0 included the C++ source
+  for Drafter and this causes problems while trying to install the package via
+  NPM since it will try and use node-gyp to build the source.
+
+
 ## 2.4.0
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "scripts": {


### PR DESCRIPTION
### Bug Fixes

- Removes unnecessary files from the NPM package. 2.4.0 included the C++ source for Drafter and this causes problems while trying to install the package via NPM since it will try and use node-gyp to build the source.