### PR TITLE
Release 2.5.0-pre.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## 2.5.0-pre.0
+
+This update now uses Drafter 3.1.0-pre.0. Please see [Drafter
+3.1.0-pre.0](https://github.com/apiaryio/drafter/releases/tag/v3.1.0-pre.0) for
+the list of changes.
+
 ## 2.4.3
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "2.4.3",
+  "version": "2.5.0-pre.0",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "scripts": {


### PR DESCRIPTION
This update now uses Drafter 3.1.0-pre.0. Please see [Drafter 3.1.0-pre.0](https://github.com/apiaryio/drafter/releases/tag/v3.1.0-pre.0) for the list of changes.