### PR TITLE
chore: Remove useless command in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,5 +24,4 @@ echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >.npmrc
 rm -fr **.gyp{,i}
 
 # Publish to npm
-npm --no-git-tag-version version $TAG
 npm publish


### PR DESCRIPTION
There are some issues with 2.5.0 release in npm. So, just bumping the version and fixing an issue with our release automation.