### PR TITLE
Allow overriding `Module` and environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # drafter.js Changelog
 
-## Master
+## 2.6.4
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # drafter.js Changelog
 
+## Master
+
+### Bug Fixes
+
+- Drafter.js will no longer override `Module` allowing drafter.js users to
+  [override the emscripten execution
+  environment](https://kripken.github.io/emscripten-site/docs/api_reference/module.html#overriding-execution-environment).
+
+
 ## 2.6.3
 
 This update now uses Drafter 3.2.3. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "scripts": {

--- a/src/pre.js
+++ b/src/pre.js
@@ -1,6 +1,10 @@
-var Module = {
-    'ready': false,
-    'log': function(text) { console.log('drafter.js: ' + text); },
-    'logErr': function(text) { console.error('drafter.js: ' + text); },
-    'onRuntimeInitialized': function() { this.ready = true; }
-};
+var Module;
+
+if (!Module) {
+  Module = {};
+}
+
+Module['ready'] = false;
+Module['log'] = function(text) { console.log('drafter.js: ' + text); };
+Module['logErr'] = function(text) { console.error('drafter.js: ' + text); };
+Module['onRuntimeInitialized'] = function() { this.ready = true; };


### PR DESCRIPTION
The code we prepend to the module forces `Module` to equal an object which prevents consumers of the library from prepending their own information.

This change will optionally create a new object, allowing other customisations to happen such as [overriding execution environment](https://kripken.github.io/emscripten-site/docs/api_reference/module.html#overriding-execution-environment).