### PR TITLE
Add WASM binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
             - drafter.js
             - drafter.js.mem
             - drafter.nomem.js
+            - drafter-non-umd.wasm
+            - drafter-non-umd.js
       - store_artifacts:
           path: lib
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## Master
+
+### Enhancements
+
+- Drafter now exposes a WebAssembly binary.
+
 ## 3.0.0-pre.1
 
 This update now uses Drafter 4.0.0-pre.1. Please see [Drafter

--- a/scripts/emcbuild.sh
+++ b/scripts/emcbuild.sh
@@ -123,3 +123,24 @@ em++ $FLAGS --memory-init-file 0 \
      -o lib/drafter.nomem.js \
      --pre-js generated/pre.js \
      --post-js generated/post.js
+
+em++ $FLAGS "build/out/$BUILD_TYPE/libdrafterjs.a" \
+     "$DRAFTER_PATH/build/out/$BUILD_TYPE/libdrafter.a" \
+     "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsnowcrash.a" \
+     "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsundown.a" \
+     "$DRAFTER_PATH/build/out/$BUILD_TYPE/libmarkdownparser.a" \
+     -s EXPORTED_FUNCTIONS="['_c_parse', '_c_validate']" \
+     -s DISABLE_EXCEPTION_CATCHING=0 \
+     -s EXPORTED_RUNTIME_METHODS="['stringToUTF8', 'getValue', 'Pointer_stringify', 'lengthBytesUTF8', 'UTF8ToString']" \
+     -s ASSERTIONS=${ASSERT} \
+     -s DOUBLE_MODE=0 \
+     -s ALLOW_MEMORY_GROWTH=1 \
+     -s NO_EXIT_RUNTIME=1 \
+     -s INVOKE_RUN=0 \
+     -s PRECISE_I64_MATH=0 \
+     -s INLINING_LIMIT=50 \
+     -s NO_FILESYSTEM=1 \
+     -s NODEJS_CATCH_EXIT=0 \
+     -s ELIMINATE_DUPLICATE_FUNCTIONS=1 \
+     -s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
+     -o lib/drafter-non-umd.js

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,6 +13,8 @@ $GITHUB_RELEASE release -u apiaryio -r drafter.js --tag $TAG
 
 $GITHUB_RELEASE upload -u apiaryio -r drafter.js --tag $TAG --name drafter.js --file lib/drafter.js
 $GITHUB_RELEASE upload -u apiaryio -r drafter.js --tag $TAG --name drafter.js.mem --file lib/drafter.js.mem
+$GITHUB_RELEASE upload -u apiaryio -r drafter.js --tag $TAG --name drafter-non-umd.wasm --file lib/drafter-non-umd.wasm
+$GITHUB_RELEASE upload -u apiaryio -r drafter.js --tag $TAG --name drafter-non-umd.js --file lib/drafter-non-umd.js
 
 # Use the CI host's NPM_TOKEN environment variable for auth
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >.npmrc


### PR DESCRIPTION
This PR adds a WASM binary for drafter.js, since we wrap the existing drafter.js files in UMD for browser compatibility that means we cannot use that in conjunction with WASM as that is unsupported by emscripten (not being too familiar with browser JS I am not sure what the standard should be, but we had requests in past by users to add UMD so likely need to keep that use-case for our users).

For now, I have named the files `drafter-non-umd.js` and `drafter-non-umd.wasm` but we need to figure out what to do before merging this pull request.

For testing purposes, the following links to the WASM files  can be used:

- https://583-28275855-gh.circle-artifacts.com/0/root/project/lib/drafter-non-umd.js
- https://583-28275855-gh.circle-artifacts.com/0/root/project/lib/drafter-non-umd.wasm

### Tasks

- [ ] Manual testing in browser
- [ ] Automated testing in CI
- [ ] Determine name for wasm/js files