### PR TITLE
Update Debian before installing git-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     docker:
       - image: apiaryio/emcc:1.38.11
     steps:
-      - run: apt-get install -y git-core
+      - run: apt-get update && apt-get install -y git-core
       - checkout
       - run: git submodule update --recursive --init
       - run: npm install


### PR DESCRIPTION
When the package database becomes out of date, it can have references to versions that have been removed from the debian package mirror which causes the build to fail.

    E: Failed to fetch http://security-cdn.debian.org/debian-security/pool/updates/main/g/git/git_2.11.0-3+deb9u3_amd64.deb  404  Not Found
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?