### PR TITLE
Release 3.0.0-pre.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## 3.0.0-pre.7 (2019-06-03)
+
+This update now uses Drafter 4.0.0-pre.7. Please see [Drafter
+4.0.0-pre.7](https://github.com/apiaryio/drafter/releases/tag/v4.0.0-pre.7) for
+the list of changes.
+
 ## 3.0.0-pre.6 (2019-05-20)
 
 This update now uses Drafter 4.0.0-pre.6. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "3.0.0-pre.6",
+  "version": "3.0.0-pre.7",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "files": [


### PR DESCRIPTION
This update now uses Drafter 4.0.0-pre.7. Please see [Drafter 4.0.0-pre.7](https://github.com/apiaryio/drafter/releases/tag/v4.0.0-pre.7) for the list of changes.