### PR TITLE
Release drafter.js 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## 3.0.2 (2019-10-29)
+
+This update now uses Drafter 4.0.2. Please see [Drafter
+4.0.2](https://github.com/apiaryio/drafter/releases/tag/v4.0.2) for the list of
+changes.
+
 ## 3.0.1 (2019-09-17)
 
 This update now uses Drafter 4.0.1. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "files": [


### PR DESCRIPTION
This update now uses Drafter 4.0.2. Please see [Drafter 4.0.2](https://github.com/apiaryio/drafter/releases/tag/v4.0.2) for the list of changes.