### PR TITLE
Reflect changes in drafter C API

### DIFF
--- a/scripts/emcbuild.sh
+++ b/scripts/emcbuild.sh
@@ -80,7 +80,7 @@ em++ $FLAGS "build/out/$BUILD_TYPE/libdrafterjs.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsnowcrash.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsundown.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libmarkdownparser.a" \
-     -s EXPORTED_FUNCTIONS="['_c_parse', '_c_validate']" \
+     -s EXPORTED_FUNCTIONS="['_drafter_init_parse_options', '_drafter_free_parse_options', '_drafter_set_name_required', '_drafter_init_serialize_options', '_drafter_free_serialize_options', '_drafter_set_sourcemaps_included', '_drafter_set_format', '_drafter_free_result', '_c_serialize_json_options', '_c_buffer_ptr', '_c_buffer_string', '_c_free_buffer_ptr', '_c_parse_to', '_c_validate_to']" \
      -s DISABLE_EXCEPTION_CATCHING=0 \
      -s EXPORTED_RUNTIME_METHODS="['stringToUTF8', 'getValue', 'Pointer_stringify', 'lengthBytesUTF8', 'UTF8ToString']" \
      -s ASSERTIONS=${ASSERT} \
@@ -105,7 +105,7 @@ em++ $FLAGS --memory-init-file 0 \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsnowcrash.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsundown.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libmarkdownparser.a" \
-     -s EXPORTED_FUNCTIONS="['_c_parse', '_c_validate']" \
+     -s EXPORTED_FUNCTIONS="['_drafter_init_parse_options', '_drafter_free_parse_options', '_drafter_set_name_required', '_drafter_init_serialize_options', '_drafter_free_serialize_options', '_drafter_set_sourcemaps_included', '_drafter_set_format', '_drafter_free_result', '_c_serialize_json_options', '_c_buffer_ptr', '_c_buffer_string', '_c_free_buffer_ptr', '_c_parse_to', '_c_validate_to']" \
      -s DISABLE_EXCEPTION_CATCHING=0 \
      -s EXPORTED_RUNTIME_METHODS="['stringToUTF8', 'getValue', 'Pointer_stringify', 'lengthBytesUTF8', 'UTF8ToString']" \
      -s ASSERTIONS=${ASSERT} \

--- a/src/cparse.h
+++ b/src/cparse.h
@@ -5,18 +5,24 @@
 extern "C" {
 #endif
 
-int c_parse(const char* source,
-            bool requireBlueprintName,
-            bool sourcemap,
-            char** result);
+struct drafter_parse_options;
+struct drafter_serialize_options;
 
-int c_validate(const char *source,
-               bool requireBlueprintName,
-               char **result);
+drafter_serialize_options* c_serialize_json_options();
+
+char** c_buffer_ptr();
+
+const char* c_buffer_string(const char**);
+
+void c_free_buffer_ptr(char**);
+
+int c_parse_to(const char*, char**, const drafter_parse_options*,
+               const drafter_serialize_options*);
+
+int c_validate_to(const char*, char**, const drafter_parse_options*);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-


### PR DESCRIPTION
Integrates changes in drafter C API (https://github.com/apiaryio/drafter/pull/766).
Optimized for small diff.

- [x]  protagonist/tjanc/drafter-capi-hide-options must be merged to protagonist/master,
- [x] the protagonist submodule must point to protagonist/master