### PR TITLE
Update to Drafter 5.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # drafter.js Changelog
 
-## Master
+## 3.1.0 (2019-03-17)
 
 This update now uses Drafter 5.0.0-rc.1. Please see [Drafter
 5.0.0-rc.1](https://github.com/apiaryio/drafter/releases/tag/v5.0.0-rc.1) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## Master
+
+This update now uses Drafter 5.0.0-rc.1. Please see [Drafter
+5.0.0-rc.1](https://github.com/apiaryio/drafter/releases/tag/v5.0.0-rc.1) for
+the list of changes.
+
 ## 3.0.2 (2019-10-29)
 
 This update now uses Drafter 4.0.2. Please see [Drafter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "files": [


### PR DESCRIPTION
This update now uses Drafter 5.0.0-rc.1. Please see [Drafter 5.0.0-rc.1](https://github.com/apiaryio/drafter/releases/tag/v5.0.0-rc.1) for the list of changes.