### PR TITLE
`generateMessageBody` and `generateMessageBodySchema` options

### DIFF
--- a/scripts/emcbuild.sh
+++ b/scripts/emcbuild.sh
@@ -75,12 +75,14 @@ DRAFTER_PATH="ext/protagonist/drafter"
 
 mkdir -p lib
 
+DRAFTER_EXPORTED_FUNCTIONS="['_drafter_init_parse_options', '_drafter_free_parse_options', '_drafter_set_name_required', '_drafter_set_skip_gen_bodies', '_drafter_set_skip_gen_body_schemas', '_drafter_init_serialize_options', '_drafter_free_serialize_options', '_drafter_set_sourcemaps_included', '_drafter_set_format', '_drafter_free_result', '_c_serialize_json_options', '_c_buffer_ptr', '_c_buffer_string', '_c_free_buffer_ptr', '_c_parse_to', '_c_validate_to']"
+
 em++ $FLAGS "build/out/$BUILD_TYPE/libdrafterjs.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libdrafter.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsnowcrash.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsundown.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libmarkdownparser.a" \
-     -s EXPORTED_FUNCTIONS="['_drafter_init_parse_options', '_drafter_free_parse_options', '_drafter_set_name_required', '_drafter_init_serialize_options', '_drafter_free_serialize_options', '_drafter_set_sourcemaps_included', '_drafter_set_format', '_drafter_free_result', '_c_serialize_json_options', '_c_buffer_ptr', '_c_buffer_string', '_c_free_buffer_ptr', '_c_parse_to', '_c_validate_to']" \
+     -s EXPORTED_FUNCTIONS="$DRAFTER_EXPORTED_FUNCTIONS" \
      -s DISABLE_EXCEPTION_CATCHING=0 \
      -s EXPORTED_RUNTIME_METHODS="['stringToUTF8', 'getValue', 'Pointer_stringify', 'lengthBytesUTF8', 'UTF8ToString']" \
      -s ASSERTIONS=${ASSERT} \
@@ -105,7 +107,7 @@ em++ $FLAGS --memory-init-file 0 \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsnowcrash.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libsundown.a" \
      "$DRAFTER_PATH/build/out/$BUILD_TYPE/libmarkdownparser.a" \
-     -s EXPORTED_FUNCTIONS="['_drafter_init_parse_options', '_drafter_free_parse_options', '_drafter_set_name_required', '_drafter_init_serialize_options', '_drafter_free_serialize_options', '_drafter_set_sourcemaps_included', '_drafter_set_format', '_drafter_free_result', '_c_serialize_json_options', '_c_buffer_ptr', '_c_buffer_string', '_c_free_buffer_ptr', '_c_parse_to', '_c_validate_to']" \
+     -s EXPORTED_FUNCTIONS="$DRAFTER_EXPORTED_FUNCTIONS" \
      -s DISABLE_EXCEPTION_CATCHING=0 \
      -s EXPORTED_RUNTIME_METHODS="['stringToUTF8', 'getValue', 'Pointer_stringify', 'lengthBytesUTF8', 'UTF8ToString']" \
      -s ASSERTIONS=${ASSERT} \

--- a/src/post.js
+++ b/src/post.js
@@ -82,7 +82,7 @@ Module['parse'] = function(blueprint, options, callback) {
       _drafter_set_skip_gen_bodies(parseOpts);
     }
     if (!options.generateMessageBodySchema) {
-      _drafter_set_skip_gen_body_schema(parseOpts);
+      _drafter_set_skip_gen_body_schemas(parseOpts);
     }
 
     var chptr = _c_buffer_ptr();

--- a/src/post.js
+++ b/src/post.js
@@ -78,11 +78,17 @@ Module['parse'] = function(blueprint, options, callback) {
     if (options.requireBlueprintName) {
       _drafter_set_name_required(parseOpts);
     }
-    if (!options.generateMessageBody) {
-      _drafter_set_skip_gen_bodies(parseOpts);
+
+    if (options.generateMessageBody !== undefined) {
+      if (!options.generateMessageBody) {
+        _drafter_set_skip_gen_bodies(parseOpts);
+      }
     }
-    if (!options.generateMessageBodySchema) {
-      _drafter_set_skip_gen_body_schemas(parseOpts);
+
+    if (options.generateMessageBodySchema !== undefined) {
+      if (!options.generateMessageBodySchema) {
+        _drafter_set_skip_gen_body_schemas(parseOpts);
+      }
     }
 
     var chptr = _c_buffer_ptr();

--- a/src/post.js
+++ b/src/post.js
@@ -40,11 +40,11 @@ Module['parse'] = function(blueprint, options, callback) {
     delete options.sync;
   }
 
-  var allowedOptions = ['generateSourceMap', 'exportSourcemap', 'requireBlueprintName'];
+  var allowedOptions = ['generateSourceMap', 'exportSourcemap', 'requireBlueprintName', 'generateMessageBody', 'generateMessageBodySchema'];
 
   Object.keys(options).forEach(function (key) {
     if (allowedOptions.indexOf(key) === -1) {
-      throw new TypeError('unrecognized option \'' + key + '\', expected: \'requireBlueprintName\', \'generateSourceMap\'');
+      throw new TypeError('unrecognized option \'' + key + '\', expected: \'requireBlueprintName\', \'generateSourceMap\', \'generateMessageBody\', \'generateMessageBodySchema\'');
     }
   });
 
@@ -77,6 +77,12 @@ Module['parse'] = function(blueprint, options, callback) {
     var parseOpts = _drafter_init_parse_options();
     if (options.requireBlueprintName) {
       _drafter_set_name_required(parseOpts);
+    }
+    if (!options.generateMessageBody) {
+      _drafter_set_skip_gen_bodies(parseOpts);
+    }
+    if (!options.generateMessageBodySchema) {
+      _drafter_set_skip_gen_body_schema(parseOpts);
     }
 
     var chptr = _c_buffer_ptr();

--- a/src/post.js
+++ b/src/post.js
@@ -44,7 +44,7 @@ Module['parse'] = function(blueprint, options, callback) {
 
   Object.keys(options).forEach(function (key) {
     if (allowedOptions.indexOf(key) === -1) {
-      throw new TypeError('unrecognized option \'' + key + '\', expected: \'requireBlueprintName\', \'generateSourceMap\', \'generateMessageBody\', \'generateMessageBodySchema\'');
+      throw new TypeError('unrecognized option \'' + key + '\', expected: \'requireBlueprintName\', \'generateMessageBody\', \'generateMessageBodySchema\', \'generateSourceMap\'');
     }
   });
 


### PR DESCRIPTION
Implements `generateMessageBody` and `generateMessageBodySchema` in the spirit of https://github.com/apiaryio/api-elements.js/pull/281 and https://github.com/apiaryio/drafter/pull/781
