### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # drafter.js Changelog
 
+## 3.2.0 (2020-04-20)
+
+* Drafter contains two new options for disabling messageBody and
+  messageBodySchema generation from MSON. `generateMessageBody` and
+  `generatedMessageBodySchema` respectively.
+
 ## 3.1.0 (2019-03-17)
 
 This update now uses Drafter 5.0.0-rc.1. Please see [Drafter

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ Supported options:
   instead get a JSON string as the result.
 - `requireBlueprintName`: Set to generate an error if the blueprint is
   missing a title.
+- `generateMessageBody` - Enable generation of messageBody from MSON (default: true)
+- `generateMessageBodySchema` - Enable generation of messageBodySchema from MSON (default: true)
 
-Or if you want just to validate it and are insterested only in parsing
+Or if you want just to validate it and are interested only in parsing
 errors and warnings:
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter.js",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Pure JS Drafter built with Emscripten",
   "main": "lib/drafter.nomem.js",
   "files": [


### PR DESCRIPTION
* Drafter contains two new options for disabling messageBody and messageBodySchema generation from MSON. `generateMessageBody` and `generatedMessageBodySchema` respectively.